### PR TITLE
feat: add spring-boot-starter-validation dependency for bean validation support

### DIFF
--- a/backend/QuizApplication/pom.xml
+++ b/backend/QuizApplication/pom.xml
@@ -54,6 +54,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/backend/QuizApplication/src/main/java/com/QuizApplication/services/QuestionService.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/services/QuestionService.java
@@ -49,7 +49,7 @@ public class QuestionService {
     public Question editQuestion(QuestionUpdateRequest updateRequest, long questionId) {
 
         //Here I used an method from the repo to get me a specific question by using the questionId
-        Question question = questionRepository.getById(questionId);
+        Question question = questionRepository.getById(questionId).orElse;
 
         //Here the first DTO converted to question Service, after that it saved to the database
         return questionRepository.save(mappingServices.convertDTOToQuestionObject(updateRequest, question));


### PR DESCRIPTION
Add Spring Boot Starter Validation dependency to enable bean validation (JSR 380) support for request and model data.