### PR TITLE
Refine difficulty level validation message and logic

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/validation/DifficultyLevelValidation.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/validation/DifficultyLevelValidation.java
@@ -11,7 +11,7 @@ import java.lang.annotation.*;
 @Constraint(validatedBy = DifficultyLevelValidator.class )
 @Documented
 public @interface DifficultyLevelValidation {
-    String message() default "DifficultyLevel must be either easy or hard or medium";
+    String message() default "DifficultyLevel must be either Easy or Hard or Medium";
 
     Class<?>[] groups() default {};
 

--- a/backend/QuizApplication/src/main/java/com/QuizApplication/validation/DifficultyLevelValidator.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/validation/DifficultyLevelValidator.java
@@ -27,7 +27,7 @@ public class DifficultyLevelValidator implements ConstraintValidator<DifficultyL
              levels.add(capitalizeWord(level.name()));
          }
 
-        return levels.contains(difficultyLevel.toUpperCase());
+        return levels.contains(capitalizeWord(difficultyLevel));
     }
 
 


### PR DESCRIPTION
This commit updates the difficulty level validation to improve clarity and ensure consistent formatting:
- Message Update
Changed validation message from:
"DifficultyLevel must be either easy or hard or medium"
to:
"DifficultyLevel must be either Easy or Hard or Medium"
for better readability and alignment with expected input format.
- Logic Update
Replaced:
levels.contains(difficultyLevel.toUpperCase())
with:
levels.contains(capitalizeWord(difficultyLevel))
so that validation now matches capitalized values (Easy, Hard, Medium) instead of fully uppercased ones.
