### PR TITLE
feat(exceptions): introduce GlobalExceptionHandler for validation and not-found errors

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.QuizApplication.ControllerAdvice;
+
+import com.QuizApplication.exceptions.QuestionNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.*;
+
+@RestControllerAdvice
+
+public class GlobalExceptionHandler
+{
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public Map<String, String> returnFiledAndItErrors(MethodArgumentNotValidException ex)
+    {
+        Map<String, String> filedAndErrors = new HashMap<>();
+
+        for (FieldError error : ex.getBindingResult().getFieldErrors())
+        {
+            filedAndErrors.put(error.getField(), error.getDefaultMessage());
+        }
+
+        return filedAndErrors;
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(QuestionNotFoundException.class)
+    public String questionNotFoundException(QuestionNotFoundException questionNotFoundException)
+    {
+        return questionNotFoundException.getMessage();
+    }
+}


### PR DESCRIPTION
Created package com.QuizApplication.exceptions.advice

Added GlobalExceptionHandler class with two methods:

returnFieldAndItErrors

Handles MethodArgumentNotValidException

Returns Map<String, String> of field names to validation messages, HTTP 400

questionNotFoundException

Handles QuestionNotFoundException

Returns the exception message, HTTP 404