### PR TITLE
refactor(controller): align QuestionController with service exceptions and HTTP statuses

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuestionController.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuestionController.java
@@ -3,6 +3,7 @@ package com.QuizApplication.Controller;
 import com.QuizApplication.dto.QuestionRequestObject;
 import com.QuizApplication.dto.QuestionUpdateRequest;
 import com.QuizApplication.entities.Question;
+import com.QuizApplication.exceptions.QuestionNotFoundException;
 import com.QuizApplication.services.QuestionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -27,11 +28,10 @@ public class QuestionController {
         return new ResponseEntity<>(questionService.getQuestions(),HttpStatus.OK);
     }
 
-
     @GetMapping("getQuestion/{questionId}")
-    public ResponseEntity<Optional<Question>> getQuestion(@PathVariable long questionId)
+    public ResponseEntity<Question> getQuestion(@PathVariable long questionId)
     {
-        // the return statements returns the question by questionId and the status 200 when a request happens
+        // In case the questions found by the questionId the question will be returned with status ok in the other case an exception not found 404
         return new ResponseEntity<>(questionService.getQuestion(questionId), HttpStatus.OK);
     }
 
@@ -41,7 +41,6 @@ public class QuestionController {
         //the return statements returns all the questions related to the specific category and the status 200 when a request happens
         return new ResponseEntity<>(questionService.getQuestionsByCategory(category), HttpStatus.OK);
     }
-
 
     @PostMapping("addquestion")
     public ResponseEntity<Question> addQuestion(@Validated @RequestBody QuestionRequestObject questionRequestObject)
@@ -60,8 +59,8 @@ public class QuestionController {
     @DeleteMapping("deletequestion/{questionId}")
     public ResponseEntity<Boolean> deleteQuestion(@PathVariable long questionId)
     {
-        //the return statements returns True and the status code 200, when  the deletion happens Successfully
-        return new ResponseEntity<>(questionService.deleteQuestion(questionId), HttpStatus.OK);
+        //the return statements returns True and the status code 204, when  the deletion happens Successfully
+        return new ResponseEntity<>(questionService.deleteQuestion(questionId), HttpStatus.NO_CONTENT);
     }
     
 }


### PR DESCRIPTION
### Summary
Update QuestionController to leverage service-layer exceptions for not-found scenarios, simplify return types, and use proper HTTP status codes for delete operations.

### Changes
Changed getQuestion return type from ResponseEntity<Optional<Question>> to ResponseEntity<Question>

No longer wrap missing-question cases in optionals; rely on QuestionNotFoundException and global handler to produce 404

Updated deleteQuestion to return HTTP 204 No Content instead of 200 OK

Retained Validated and request mappings without altering endpoint paths