### PR TITLE
feat(exceptions): add QuestionAlreadyExistsException to prevent duplicate questions

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/exceptions/QuestionAlreadyExistsException.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/exceptions/QuestionAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.QuizApplication.exceptions;
+
+public class QuestionAlreadyExistsException extends RuntimeException {
+    public QuestionAlreadyExistsException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
### Summary
Added a custom runtime exception to handle cases where a question with the same title or content already exists in the database.

### Motivation
Prevent duplicate entries from being added
Improve user feedback when attempting to submit an already existing question
Prepare for future enhancements like uniqueness checks or conflict resolution strategies

### Changes
Created QuestionAlreadyExistsException in com.QuizApplication.exceptions
Exception extends RuntimeException and accepts a custom message

