### PR TITLE
feat(exception-handler): add handler for QuestionAlreadyExistsException with 422 response

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.QuizApplication.ControllerAdvice;
 
+import com.QuizApplication.exceptions.QuestionAlreadyExistsException;
 import com.QuizApplication.exceptions.QuestionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
@@ -35,5 +36,12 @@ public class GlobalExceptionHandler
     public String questionNotFoundException(QuestionNotFoundException questionNotFoundException)
     {
         return questionNotFoundException.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    @ExceptionHandler(QuestionAlreadyExistsException.class)
+    public String questionAlreadyExistsException(QuestionAlreadyExistsException questionAlreadyExistsException)
+    {
+        return questionAlreadyExistsException.getMessage();
     }
 }


### PR DESCRIPTION
### Summary
Extend the global exception handling mechanism to catch and respond to QuestionAlreadyExistsException with a meaningful message and HTTP 422 status.

### Motivation
Prevent silent failures or vague error responses when duplicate questions are submitted

Improve client-side feedback with clear messaging

Align with RESTful standards by using 422 Unprocessable Entity for semantic validation errors

### Changes
Added a new method in GlobalExceptionHandler.