### PR TITLE
feat(service): validate question title uniqueness before insertion

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/services/QuestionService.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/services/QuestionService.java
@@ -3,6 +3,7 @@ package com.QuizApplication.services;
 import com.QuizApplication.dto.QuestionRequestObject;
 import com.QuizApplication.dto.QuestionUpdateRequest;
 import com.QuizApplication.entities.Question;
+import com.QuizApplication.exceptions.QuestionAlreadyExistsException;
 import com.QuizApplication.exceptions.QuestionNotFoundException;
 import com.QuizApplication.repository.QuestionRepository;
 import org.aspectj.weaver.patterns.TypePatternQuestions;
@@ -35,6 +36,12 @@ public class QuestionService {
         //Here I have declared a new question to add the dto value to it
         Question question = new Question();
 
+        //Here I am checking if there is a question exists with the same given title
+        if (questionRepository.existsByQuestionTitle(questionRequestObject.getQuestionTitle()))
+        {
+            throw new QuestionAlreadyExistsException("Question Already Exists with the following title : " + questionRequestObject.getQuestionTitle());
+        }
+
         //Here the code first convert DTO to OBJ then it save it in the database after that it returned to the user
         return questionRepository.save(mappingServices.convertDTOToQuestionObject(questionRequestObject, question));
     }
@@ -43,7 +50,7 @@ public class QuestionService {
 
         //Here I used an method from the repo to find me a specific question by using the questionId, in case the question not found an error will be thrown
         Question question = questionRepository.findById(questionId)
-                .orElseThrow(() -> new QuestionNotFoundException("question with " + questionId + " not found"));
+                .orElseThrow(() -> new QuestionNotFoundException("question with " + questionId + " Id not found"));
 
         //Here the first DTO converted to question Service, after that it saved to the database
         return questionRepository.save(mappingServices.convertDTOToQuestionObject(updateRequest, question));
@@ -54,7 +61,7 @@ public class QuestionService {
         //The if statement checks if there a question already exists by the given id in case no an exception will be thrown
         if (!questionRepository.existsById(questionId))
         {
-            throw new QuestionNotFoundException("question with " + questionId + " not found");
+            throw new QuestionNotFoundException("question with " + questionId + " Id not found");
         }
 
         //I have called the deleteById method to delete the question from the database
@@ -70,7 +77,7 @@ public class QuestionService {
         * in the other case an exception will be thrown QuestionNotFoundException
         * */
         return questionRepository.findById(questionId).
-                orElseThrow(() -> new QuestionNotFoundException("question with " + questionId + " not found"));
+                orElseThrow(() -> new QuestionNotFoundException("question with " + questionId + " Id not found"));
     }
 
     public List<Question> getQuestionsByCategory(String category) {


### PR DESCRIPTION
### Summary
Added a pre-insertion check in QuestionService.addQuestion(...) to prevent duplicate questions based on title. If a match is found, the method throws QuestionAlreadyExistsException, which is handled globally.

### Motivation
Enforce uniqueness of questions at the service level
Provide clear feedback to clients when attempting to submit a duplicate
Strengthen data integrity and user experience

### Changes
Added logic in addQuestion(...):
if (questionRepository.existsByQuestionTitle(questionRequestObject.getQuestionTitle())) {
    throw new QuestionAlreadyExistsException("Question Already Exists with the following title : " + questionRequestObject.getQuestionTitle());
}
Ensures that duplicate titles are caught before saving to the database
Relies on the global exception handler to return HTTP 422 with a descriptive message