### PR TITLE
feat(entity): add Quiz entity with ManyToMany relationship to Question

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/entities/Quiz.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/entities/Quiz.java
@@ -1,0 +1,27 @@
+package com.QuizApplication.entities;
+
+import com.QuizApplication.dto.QuizQuestionDto;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class Quiz {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private long quizId;
+
+    private String quizTitle;
+    private String category;
+    private int numberOfQuestions;
+    private String difficultyLevel;
+
+    @ManyToMany
+    List<Question> Questions;
+}


### PR DESCRIPTION
Summary
Introduce a new Quiz entity to represent quizzes in the application. Each quiz can contain multiple questions, and questions can belong to multiple quizzes.

Changes
Added Quiz entity with fields:
1. quizId (auto-generated primary key)
2. quizTitle
3. category
4. numberOfQuestions
5. difficultyLevel
6. Defined @ManyToMany relationship with Question entity