### PR TITLE
feat(dto): add QuizDto to expose essential quiz data only

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/dto/QuizDto.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/dto/QuizDto.java
@@ -1,0 +1,22 @@
+package com.QuizApplication.dto;
+
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+
+//I have created this quiz dto to show the necessary data only
+public class QuizDto {
+    private long quizId;
+
+    private String quizTitle;
+    private String category;
+    private int numberOfQuestions;
+    private String difficultyLevel;
+
+}


### PR DESCRIPTION
### Summary
Added a QuizDto class to represent quiz data in API responses. This DTO ensures that only the necessary fields are exposed to clients, keeping entity details encapsulated.

### Changes
Created QuizDto with fields:
1. quizId
2. quizTitle
3. category
4. numberOfQuestions
5. difficultyLevel
6. Annotated with Lombok: @Data, @NoArgsConstructor, @AllArgsConstructor