### PR TITLE
feat(controller): add generateQuiz endpoint and wire QuizServices into QuizController

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuizController.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuizController.java
@@ -24,5 +24,16 @@ import java.util.List;
 @RequestMapping("quiz")
 @Validated
 public class QuizController {
+    @Autowired
+    private QuizServices quizServices;
+
+    @PostMapping("/create")
+    public ResponseEntity<QuizDto> generateQuiz(@NotBlank(message = "category must not be empty") @RequestParam() String category,
+                                                @Positive(message = "Number of questions must be greater than 0") @RequestParam(name = "noOfQuestions"  ) int numberOfQuestions,
+                                                @RequestParam(required = false, defaultValue = "All") String difficultyLevel,
+                                                @NotBlank(message = "QuizTitle must not be empty") @RequestParam String quizTitle)
+    {
+        return new ResponseEntity<>(quizServices.createQuiz(category, numberOfQuestions, difficultyLevel, quizTitle), HttpStatus.CREATED);
+    }
 
 }


### PR DESCRIPTION
### Summary
Combined the injection of QuizServices with a new generateQuiz endpoint in QuizController. This endpoint validates input parameters and delegates quiz creation to the service layer, returning a QuizDto with 201 Created.
### Changes
1. Injected QuizServices into QuizController using @Autowired
2. Added @PostMapping("/create") endpoint generateQuiz(...)
3. Validated request parameters (category, quizTitle, numberOfQuestions, difficultyLevel)
4. Returned ResponseEntity<QuizDto> with HttpStatus.CREATED