### PR TITLE
feat(mapping): add convertingQuizToDto method in MappingServices

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/services/MappingServices.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/services/MappingServices.java
@@ -2,11 +2,17 @@ package com.QuizApplication.services;
 
 import com.QuizApplication.dto.QuestionRequestObject;
 import com.QuizApplication.dto.QuestionUpdateRequest;
+import com.QuizApplication.dto.QuizDto;
+import com.QuizApplication.dto.QuizQuestionDto;
 import com.QuizApplication.entities.Question;
+import com.QuizApplication.entities.Quiz;
 import com.QuizApplication.entities.difficulty;
 import com.QuizApplication.repository.QuestionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.QuizApplication.Utilites.StringUtility.capitalizeWord;
 
@@ -47,4 +53,17 @@ public class MappingServices {
        return question;
    }
 
+
+
+    public QuizDto convertingQuizToDto(Quiz quiz)
+    {
+        QuizDto quizDto = new QuizDto();
+        quizDto.setQuizId(quiz.getQuizId());
+        quizDto.setQuizTitle(quiz.getQuizTitle());
+        quizDto.setCategory(quiz.getCategory());
+        quizDto.setNumberOfQuestions(quiz.getNumberOfQuestions());
+        quizDto.setDifficultyLevel(quiz.getDifficultyLevel());
+
+        return  quizDto;
+    }
 }


### PR DESCRIPTION
### Summary
Added a mapping method in MappingServices to convert a Quiz entity into a QuizDto. This ensures only the necessary quiz data is exposed in API responses.

### Changes
Added method in MappingServices:
**java**
```
public QuizDto convertingQuizToDto(Quiz quiz) {
    QuizDto quizDto = new QuizDto();
    quizDto.setQuizId(quiz.getQuizId());
    quizDto.setQuizTitle(quiz.getQuizTitle());
    quizDto.setCategory(quiz.getCategory());
    quizDto.setNumberOfQuestions(quiz.getNumberOfQuestions());
    quizDto.setDifficultyLevel(quiz.getDifficultyLevel());
    return quizDto;
}
```