### PR TITLE
feat(service): add getListOfQuestions method to fetch questions by category and difficulty

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/services/QuizServices.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/services/QuizServices.java
@@ -34,4 +34,29 @@ public class QuizServices {
     @Autowired
     private MappingServices mappingServices;
 
+
+
+
+    //this method generate questionList based on the user request
+    public List<Question> getListOfQuestions(String category, String difficultyLevel)
+    {
+        //Here converting the enum values to string
+        List<String> difficultyLevels = stream(difficulty.values()).map(Enum::toString).toList();
+
+        List<Question> questionList = new ArrayList<>();
+
+        //here checking if the list doesn't contains the given difficultyLevel from the user for the seek of simplicity I include all the levels
+        if (difficultyLevel.isBlank() || !difficultyLevels.contains(difficultyLevel))
+        {
+            questionList = questionRepository.findAllByCategory(category);
+        }
+        //here if the difficulty level valid list of questions will be created base on CategoryAndDifficultyLevel
+        else if (!difficultyLevel.isBlank() && !category.isBlank() && difficultyLevels.contains(difficultyLevel))
+        {
+            questionList = questionRepository.findAllByCategoryAndDifficultyLevel(category, difficulty.valueOf(difficultyLevel));
+        }
+
+        return questionList;
+    }
+
 }


### PR DESCRIPTION
### Summary
Added a new method in QuizServices to generate a list of questions based on user input for category and difficulty level. The method validates the difficulty input against enum values and falls back to category-only queries if invalid.


### Changes
**Added method in QuizServices:
java**
```
public List<Question> getListOfQuestions(String category, String difficultyLevel) {
    List<String> difficultyLevels = stream(difficulty.values()).map(Enum::toString).toList();
    List<Question> questionList = new ArrayList<>();

    if (difficultyLevel.isBlank() || !difficultyLevels.contains(difficultyLevel)) {
        questionList = questionRepository.findAllByCategory(category);
    } else if (!difficultyLevel.isBlank() && !category.isBlank() && difficultyLevels.contains(difficultyLevel)) {
        questionList = questionRepository.findAllByCategoryAndDifficultyLevel(category, difficulty.valueOf(difficultyLevel));
    }

    return questionList;
}
```