### PR TITLE
feat(controller): add deleteQuiz endpoint to remove quizzes by ID

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuizController.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuizController.java
@@ -36,4 +36,10 @@ public class QuizController {
         return new ResponseEntity<>(quizServices.createQuiz(category, numberOfQuestions, difficultyLevel, quizTitle), HttpStatus.CREATED);
     }
 
+    @DeleteMapping("/delete/{quizId}")
+    public ResponseEntity<String> deleteQuiz(@PathVariable int quizId)
+    {
+        return new ResponseEntity<>(quizServices.deleteQuiz(quizId), HttpStatus.NO_CONTENT);
+    }
+
 }


### PR DESCRIPTION
### Summary
Added a new endpoint in QuizController to delete quizzes by ID. The endpoint delegates deletion logic to QuizServices and returns an appropriate HTTP response.
### Changes
Added @DeleteMapping("/delete/{quizId}") in QuizController

Delegated deletion to quizServices.deleteQuiz(quizId)

Returned ResponseEntity with appropriate status code