### PR TITLE
feat(exception): add handler for ConstraintViolationException to return validation errors as 400

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
@@ -57,4 +57,19 @@ public class GlobalExceptionHandler
         return resourcesNotFoundException.getMessage();
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ConstraintViolationException.class)
+    public Map<String, String> handlingConstraintViolationException(ConstraintViolationException constraintViolationException)
+    {
+        Map<String, String> map = new HashMap<>();
+
+        for(ConstraintViolation<?> errors : constraintViolationException.getConstraintViolations())
+        {
+            map.put(String.valueOf(errors.getPropertyPath()), errors.getMessage());
+        }
+
+        return map;
+    }
+
+
 }


### PR DESCRIPTION
### Summary
Added an exception handler in GlobalExceptionHandler to catch ConstraintViolationException and return a 400 Bad Request response. This ensures that when users provide invalid input (e.g., blank category, negative number of questions, or empty quiz title), the API responds with clear validation error messages.