### PR TITLE
feat(controller): add updateQuiz endpoint with validation and service integration

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuizController.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/Controller/QuizController.java
@@ -36,6 +36,16 @@ public class QuizController {
         return new ResponseEntity<>(quizServices.createQuiz(category, numberOfQuestions, difficultyLevel, quizTitle), HttpStatus.CREATED);
     }
 
+    @PutMapping("/update/{quizId}")
+    public ResponseEntity<QuizDto> updateQuiz(@PathVariable int quizId,
+                                              @NotBlank(message = "category must not be empty") @RequestParam() String category,
+                                              @Positive(message = "Number of questions must be greater than 0") @RequestParam(name = "noOfQuestions"  ) int numberOfQuestions,
+                                              @RequestParam(required = false, defaultValue = "All") String difficultyLevel,
+                                              @NotBlank(message = "QuizTitle must not be empty") @RequestParam String quizTitle)
+    {
+        return new ResponseEntity<>(quizServices.updateQuiz(quizId, category, numberOfQuestions, difficultyLevel, quizTitle), HttpStatus.OK);
+    }
+
     @DeleteMapping("/delete/{quizId}")
     public ResponseEntity<String> deleteQuiz(@PathVariable int quizId)
     {


### PR DESCRIPTION
### Summary
Added an updateQuiz endpoint in QuizController to update quiz details by ID. The endpoint validates input parameters, delegates update logic to QuizServices, and returns the updated quiz as a QuizDto with HTTP 200 OK.



### Changes

- Added @PutMapping("/update/{quizId}") in QuizController
- Applied validation annotations:
- @NotBlank for category and quizTitle
- @Positive for numberOfQuestions
- Default value "All" for difficultyLevel
- Delegated update logic to quizServices.updateQuiz(...)
- Returned updated quiz as QuizDto with HttpStatus.OK