### PR TITLE
feat(exception): add BadRequestException and integrate with GlobalExceptionHandler

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/exceptions/BadRequestException.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.QuizApplication.exceptions;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Summary
Added a custom BadRequestException to represent invalid client requests (e.g., when the requested number of questions exceeds the available questions). Integrated it into the global exception handler to return structured 400 Bad Request responses with clear error messages.