### PR TITLE
feat(exception): handle BadRequestException with @ExceptionHandler

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
@@ -71,5 +71,13 @@ public class GlobalExceptionHandler
         return map;
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BadRequestException.class)
+    public String badRequestException(BadRequestException badRequestException)
+    {
+        return badRequestException.getMessage();
+    }
+
+
 
 }


### PR DESCRIPTION
### Summary
Added a new exception handler for BadRequestException in the GlobalExceptionHandler. This ensures that whenever a BadRequestException is thrown (e.g., when the requested number of questions exceeds the available questions), the API responds with a 400 Bad Request status and a clear error message.