### PR TITLE
feat(exception): handle MethodArgumentTypeMismatchException with custom error message

### DIFF
--- a/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
+++ b/backend/QuizApplication/src/main/java/com/QuizApplication/ControllerAdvice/GlobalExceptionHandler.java
@@ -77,7 +77,20 @@ public class GlobalExceptionHandler
     {
         return badRequestException.getMessage();
     }
+    
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public String handlerMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException methodArgumentTypeMismatchException)
+    {
+        String fieldName = methodArgumentTypeMismatchException.getName();
+        String Causes = methodArgumentTypeMismatchException.getCause().getMessage();
+        String exceptedDatatype = methodArgumentTypeMismatchException.getRequiredType().toString();
 
 
+        String error = String.format("%s : excepted the following DataType \"%s\" but got this : %s", fieldName, exceptedDatatype, Causes);
+
+
+        return error ;
+    }
 
 }


### PR DESCRIPTION
### Summary
Added a new exception handler for MethodArgumentTypeMismatchException in GlobalExceptionHandler.
Returns 400 Bad Request when request parameters or path variables cannot be converted to the expected type.
Provides a clear error message indicating the field, expected type, and the invalid value.